### PR TITLE
✨feat:댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/YNN/controller/CommentController.java
+++ b/src/main/java/com/example/YNN/controller/CommentController.java
@@ -21,6 +21,7 @@ public class CommentController {
     private final CommentServiceImpl commentService;
     private final JwtUtil jwtUtil;
 
+    //** 댓글 작성 **//
     @PostMapping("/api/comment/add") // 댓글 작성 api
     public ResponseEntity<String> addComment(@RequestBody CommentRequestDTO commentRequestDTO,
                                              @RequestHeader("Authorization") String token) {
@@ -36,6 +37,7 @@ public class CommentController {
         }
     }
 
+    //** 게시물 댓글 조회 **//
     @GetMapping("/api/comment/post/{postId}") // 댓글 목록 가져오기 api
     public ResponseEntity<List<CommentResponseDTO>> getCommentsByPost(@PathVariable Long postId,
                                                                       @RequestHeader("Authorization") String token) {
@@ -48,6 +50,22 @@ public class CommentController {
             return ResponseEntity.ok(comments);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(null);
+        }
+    }
+
+    //** 댓글 삭제 **//
+    @DeleteMapping("/api/comment/delete/{commentId}") // 댓글 삭제 API
+    public ResponseEntity<String> deleteComment(@PathVariable Long commentId,
+                                                @RequestHeader("Authorization") String token) {
+
+        if (!jwtUtil.validationToken(jwtUtil.getAccessToken(token))) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰");
+        }
+        try {
+            commentService.deleteComment(commentId, token);
+            return ResponseEntity.ok("댓글 삭제 완료");
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("댓글 삭제 실패: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/example/YNN/service/CommentService.java
+++ b/src/main/java/com/example/YNN/service/CommentService.java
@@ -10,4 +10,6 @@ public interface CommentService {
     void addComment(CommentRequestDTO commentRequestDTO, String token); // 댓글 작성
 
     List<CommentResponseDTO> getCommentsByPost(Long postId); // 게시글 목록 List로 가져오기
+
+    void deleteComment(Long commentId, String token); // 댓글 삭제
 }

--- a/src/main/java/com/example/YNN/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/YNN/service/CommentServiceImpl.java
@@ -30,7 +30,7 @@ public class CommentServiceImpl implements CommentService {
     private final JwtUtil jwtUtil;
 
     @Override
-    public void addComment(CommentRequestDTO commentRequestDTO, String token) throws IOException { // 댓글 추가하는 로직
+    public void addComment(CommentRequestDTO commentRequestDTO, String token) throws IOException { //** 댓글 추가하는 로직 **//
         log.info("댓글 추가 요청 수신됨: {}", commentRequestDTO);
 
         try {
@@ -64,7 +64,7 @@ public class CommentServiceImpl implements CommentService {
     
     @Transactional(readOnly = true)
     @Override
-    public List<CommentResponseDTO> getCommentsByPost(Long postId) { // 게시글의 댓글 조회하는 로직
+    public List<CommentResponseDTO> getCommentsByPost(Long postId) { //** 게시글의 댓글 조회하는 로직 **//
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("게시물을 찾을 수 없습니다.")); // 마찬가지로 람다로 예외 처리
 
@@ -76,5 +76,24 @@ public class CommentServiceImpl implements CommentService {
                         .postDate(comment.getCreatedAt().toString())
                         .build())
                 .toList();
+    }
+
+    @Override
+    public void deleteComment(Long commentId, String token) { //** 댓글 삭제 로직 **//
+        try {
+            String userId = jwtUtil.getUserId(token);
+            Comment comment = commentRepository.findById(commentId)
+                    .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+
+            if (!comment.getUser().getUserId().equals(userId)) { // 댓글 작성자만 삭제할 수 있게 검증
+                throw new RuntimeException("댓글을 삭제할 권한이 없습니다.");
+            }
+
+            commentRepository.delete(comment); // 댓글 삭제
+            log.info("댓글 삭제 성공: {}", commentId);
+        } catch (Exception e) {
+            log.error("댓글 삭제 중 오류 발생: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
## 주요 추가 기능

- 댓글 삭제 기능 추가
- 해당 유저가 작성한 댓글이 아닌 댓글 삭제 요청이 올 시, 못하도록 Block

### 댓글 삭제 API < deleteComment >

```java
@DeleteMapping("/api/comment/delete/{commentId}") // 댓글 삭제 API
    public ResponseEntity<String> deleteComment(@PathVariable Long commentId,
                                                @RequestHeader("Authorization") String token) {

        if (!jwtUtil.validationToken(jwtUtil.getAccessToken(token))) {
            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰");
        }
        try {
            commentService.deleteComment(commentId, token);
            return ResponseEntity.ok("댓글 삭제 완료");
        } catch (Exception e) {
            return ResponseEntity.badRequest().body("댓글 삭제 실패: " + e.getMessage());
        }
    }
```

### Logic < deleteComment >

```java
@Override
    public void deleteComment(Long commentId, String token) { //** 댓글 삭제 로직 **//
        try {
            String userId = jwtUtil.getUserId(token);
            Comment comment = commentRepository.findById(commentId)
                    .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));

            if (!comment.getUser().getUserId().equals(userId)) { // 댓글 작성자만 삭제할 수 있게 검증
                throw new RuntimeException("댓글을 삭제할 권한이 없습니다.");
            }

            commentRepository.delete(comment); // 댓글 삭제
            log.info("댓글 삭제 성공: {}", commentId);
        } catch (Exception e) {
            log.error("댓글 삭제 중 오류 발생: {}", e.getMessage(), e);
            throw e;
        }
    }
```