### PR TITLE
🐛fix:게시물 댓글 조회 시 최신순으로 조회가 안되는 버그 수정

### DIFF
--- a/src/main/java/com/example/YNN/repository/CommentRepository.java
+++ b/src/main/java/com/example/YNN/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.example.YNN.repository;
 
 import com.example.YNN.model.Comment;
 import com.example.YNN.model.Post;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +11,6 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    List<Comment> findByPost(Post post); // 게시글 댓글 조회
+    //** 정렬을 해서 조회 **//
+    List<Comment> findByPost(Post post, Sort sort); // 게시글 댓글 조회
 }

--- a/src/main/java/com/example/YNN/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/YNN/service/CommentServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.YNN.util.JwtUtil;
 import io.jsonwebtoken.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,7 +69,8 @@ public class CommentServiceImpl implements CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("게시물을 찾을 수 없습니다.")); // 마찬가지로 람다로 예외 처리
 
-        List<Comment> comments = commentRepository.findByPost(post); // 댓글 repo에서 post 조회해서 댓글들 다 List로 저장
+        //** 댓글 조회할 때 "createdAt"을 내림차순으로 정렬(최신순) **//
+        List<Comment> comments = commentRepository.findByPost(post, Sort.by(Sort.Direction.DESC, "createdAt")); // 댓글 repo에서 post 조회해서 댓글들 다 List로 저장
         return comments.stream()
                 .map(comment -> CommentResponseDTO.builder()
                         .commentId(comment.getCommentId())


### PR DESCRIPTION
## 버그 수정 < 최신 순으로 댓글 조회 >


### Comment Repository
```java
@Repository
public interface CommentRepository extends JpaRepository<Comment, Long> {

    //** 정렬을 해서 조회 **//
    List<Comment> findByPost(Post post, Sort sort); // 게시글 댓글 조회
}
```

### CommentService Impl
```java
@Transactional(readOnly = true)
    @Override
    public List<CommentResponseDTO> getCommentsByPost(Long postId) { //** 게시글의 댓글 조회하는 로직 **//
        Post post = postRepository.findById(postId)
                .orElseThrow(() -> new RuntimeException("게시물을 찾을 수 없습니다.")); // 마찬가지로 람다로 예외 처리

        //** 댓글 조회할 때 "createdAt"을 내림차순으로 정렬(최신순) **//
        List<Comment> comments = commentRepository.findByPost(post, Sort.by(Sort.Direction.DESC, "createdAt")); // 댓글 repo에서 post 조회해서 댓글들 다 List로 저장
        return comments.stream()
                .map(comment -> CommentResponseDTO.builder()
                        .commentId(comment.getCommentId())
                        .content(comment.getContent())
                        .postDate(comment.getCreatedAt().toString())
                        .build())
                .toList();
    }
```