### PR TITLE
🐛fix:게시물 Null처리

### DIFF
--- a/src/main/java/com/example/YNN/DTO/PostResponseDTO.java
+++ b/src/main/java/com/example/YNN/DTO/PostResponseDTO.java
@@ -46,6 +46,9 @@ public class PostResponseDTO {
     // 사용자가 좋아요를 눌렀는지에 대한 여부
     private boolean likedByUser;
 
+    //상태 메세지 전송
+    private String message;
+
     public PostResponseDTO(String error) {
         this.error=error;
     }

--- a/src/main/java/com/example/YNN/service/PostServiceImpl.java
+++ b/src/main/java/com/example/YNN/service/PostServiceImpl.java
@@ -90,11 +90,19 @@ public class PostServiceImpl implements PostService{
         return post.getPostId();
     }
     //최신 게시물 불러오기
-    @Transactional
+
     @Override
     public PostResponseDTO getNewPost(String token) {
 
         List<Post> postList=postRepository.findAllByOrderByCreatedAtDesc();
+        //글이 없는 경우
+        if(postList.isEmpty()){
+            return PostResponseDTO
+                    .builder()
+                    .message("NULL")
+                    .build();
+        }
+        //게
         Post newPost= postList.get(0);
 
         //사진가져오기
@@ -131,10 +139,17 @@ public class PostServiceImpl implements PostService{
         return postResponseDTO;
     }
     //인기 게시물 가져오기
-    @Transactional
+
     @Override
     public PostResponseDTO getPopular(String token) {
         List<Post> postList=postRepository.findAllByOrderByLikeCntDesc();
+        //글이 없는 경우
+        if(postList.isEmpty()){
+            return PostResponseDTO
+                    .builder()
+                    .message("NULL")
+                    .build();
+        }
         Post popularPost= postList.get(0);
 
         //사진가져오기
@@ -174,7 +189,7 @@ public class PostServiceImpl implements PostService{
 
     // 게시물 상세보기
     @Override
-    @Transactional
+
     public PostResponseDTO getDetail(Long postId,String token) {
         Post findPost=postRepository.findByPostId(postId);
         //사진 정보 불러오기


### PR DESCRIPTION
## 구현내용
- 메인페이지의 인기 게시물, 최신게시물이 존재하지 않는 경우 에러만을 반환해서 클라이언트 입장에서는 게시물 존재 여부를 알 수 없음
- `200`값으로 반환하고 `message`에 `NULL`를 리턴하여 클라이언트가 게시물이 존재하지 않는다는 것을 인지 가능하도록 수정.

## 구현코드
```java
//글이 없는 경우
if(postList.isEmpty()){
    return PostResponseDTO
               .builder()
              .message("NULL")
              .build();
}
```