### PR TITLE
🐛fix:친구 추가 에러핸들링

### DIFF
--- a/src/main/java/com/example/YNN/config/SecurityConfig.java
+++ b/src/main/java/com/example/YNN/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://127.0.0.1:5173","http://localhost:5173", "http://43.202.47.254:8080")); // 명시적으로 허용할 출처
+        configuration.setAllowedOrigins(Arrays.asList("http://127.0.0.1:5173","http://localhost:5173", "http://43.202.47.254:8080","http://yeungnam-nyang.site","http://yeungnam-nyang.site.s3-website.ap-northeast-2.amazonaws.com")); // 명시적으로 허용할 출처
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true); // 자격 증명 허용

--- a/src/main/java/com/example/YNN/constants/ErrorCode.java
+++ b/src/main/java/com/example/YNN/constants/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.example.YNN.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    //409
+    NOT_EXITS_USER(409,"유저의 아이디가 존재하지 않습니다."),
+    NOT_INPUT_MY_USER_ID(409,"자신의 유저아이디는 입력할 수 없습니다."),
+    EXITS_FRIENDS_USER_ID(409,"이미 친구인 상태입니다.");
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/example/YNN/controller/FriendController.java
+++ b/src/main/java/com/example/YNN/controller/FriendController.java
@@ -30,13 +30,10 @@ public class FriendController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
-        try {
-            String userId = jwtUtil.getUserId(token); // 토큰에서 userId 추출
-            FriendResponseDTO response = friendService.addFriend(userId, friendRequestDTO.getFriendId());
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(null);
-        }
+        String userId = jwtUtil.getUserId(token); // 토큰에서 userId 추출
+        FriendResponseDTO response = friendService.addFriend(userId, friendRequestDTO.getFriendId());
+        return ResponseEntity.ok(response);
+
     }
 
     // 친구 상태 확인하는 api

--- a/src/main/java/com/example/YNN/error/CustomException.java
+++ b/src/main/java/com/example/YNN/error/CustomException.java
@@ -1,0 +1,12 @@
+package com.example.YNN.error;
+
+import com.example.YNN.constants.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+    private final String message;
+}

--- a/src/main/java/com/example/YNN/error/ErrorResponse.java
+++ b/src/main/java/com/example/YNN/error/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.example.YNN.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final int status; // HTTP 상태 코드
+    private final String message; // 사용자에게 전달할 메시지
+}

--- a/src/main/java/com/example/YNN/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/YNN/error/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.example.YNN.error;
+
+import com.example.YNN.constants.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@ControllerAdvice
+@RestControllerAdvice
+
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getStatus(),ex.getMessage()));
+    }
+}

--- a/src/main/java/com/example/YNN/service/FriendServiceImpl.java
+++ b/src/main/java/com/example/YNN/service/FriendServiceImpl.java
@@ -2,6 +2,8 @@ package com.example.YNN.service;
 
 import com.example.YNN.DTO.FriendResponseDTO;
 import com.example.YNN.Enums.FriendRequestStatus;
+import com.example.YNN.constants.ErrorCode;
+import com.example.YNN.error.CustomException;
 import com.example.YNN.model.Friend;
 import com.example.YNN.model.User;
 import com.example.YNN.repository.FriendRepository;
@@ -26,20 +28,25 @@ public class FriendServiceImpl implements FriendService {
     @Transactional
     public FriendResponseDTO addFriend(String userId, String friendId) { // 여기서 토큰은 로그인 한 유저의 token임!
         if (userId.equals(friendId)) {
-            throw new IllegalArgumentException("자기 자신에게 친구 요청을 보낼 수 없습니다.");
+            throw new CustomException(ErrorCode.NOT_INPUT_MY_USER_ID,ErrorCode.NOT_INPUT_MY_USER_ID.getMessage());
         }
 
         User user = userRepository.findByUserId(userId);
         if (user == null) {
-            throw new IllegalArgumentException("로그인한 유저가 존재하지 않습니다.");
+            throw new CustomException(ErrorCode.NOT_EXITS_USER,ErrorCode.NOT_EXITS_USER.getMessage());
         }
 
         User friendUser = userRepository.findByUserId(friendId);
         if (friendUser == null) {
-            throw new IllegalArgumentException("해당 유저는 존재하지 않습니다.");
+            throw new CustomException(ErrorCode.NOT_EXITS_USER,ErrorCode.NOT_EXITS_USER.getMessage());
         }
         // 이미 존재하는 친구 요청 조회 (거절된 상태 포함)
         Friend existingFriend = friendRepository.findByUser_UserIdAndFriendId(userId, friendId);
+
+        //이미 친구인 경우
+        if(existingFriend.getStatus().equals(FriendRequestStatus.ACCEPTED)){
+            throw new CustomException(ErrorCode.EXITS_FRIENDS_USER_ID,ErrorCode.EXITS_FRIENDS_USER_ID.getMessage());
+        }
 
         // 요청이 이미 존재하고, 상태가 거절된 경우 요청 상태를 다시 REQUESTED로 변경
         if (existingFriend != null) {


### PR DESCRIPTION
## 구현 내용
- 친구 추가 시 발생할 수 있는 자신의 아이디 입력, 존재하지 않는 아이디 입력, 이미 친구인 상태에서의 요청에 대해 클라이언트가 확인 가능하도록 변경
- `409`에러 코드와 함께 에러메세지 전송

## 구현코드
#### CustomException
```java 
@AllArgsConstructor
@Getter
public class CustomException extends RuntimeException{
    private final ErrorCode errorCode;
    private final String message;
}

```

#### ErrorResponse
```java
@Getter
@AllArgsConstructor
public class ErrorResponse {
    private final int status; // HTTP 상태 코드
    private final String message; // 사용자에게 전달할 메시지
}
```

#### FriendServiceImpl
```java
 if (userId.equals(friendId)) {
            throw new CustomException(ErrorCode.NOT_INPUT_MY_USER_ID,ErrorCode.NOT_INPUT_MY_USER_ID.getMessage());
        }

        User user = userRepository.findByUserId(userId);
        if (user == null) {
            throw new CustomException(ErrorCode.NOT_EXITS_USER,ErrorCode.NOT_EXITS_USER.getMessage());
        }

        User friendUser = userRepository.findByUserId(friendId);
        if (friendUser == null) {
            throw new CustomException(ErrorCode.NOT_EXITS_USER,ErrorCode.NOT_EXITS_USER.getMessage());
        }
        // 이미 존재하는 친구 요청 조회 (거절된 상태 포함)
        Friend existingFriend = friendRepository.findByUser_UserIdAndFriendId(userId, friendId);

        //이미 친구인 경우
        if(existingFriend.getStatus().equals(FriendRequestStatus.ACCEPTED)){
            throw new CustomException(ErrorCode.EXITS_FRIENDS_USER_ID,ErrorCode.EXITS_FRIENDS_USER_ID.getMessage());
        }
```