### PR TITLE
🐛fix:친구 추가 요청 로직 수정

### DIFF
--- a/src/main/java/com/example/YNN/model/Friend.java
+++ b/src/main/java/com/example/YNN/model/Friend.java
@@ -17,7 +17,7 @@ public class Friend {
     private Long id; // 기본키 세팅
     /** 복합키를 이용해서 구현하려 했으나, 구조가 복잡해지고 크게 성능이 좋아지지 않을 것 같아서 id 기본키를 따로 세팅. **/
 
-    @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
     @JoinColumn(name = "userId")
     private User user; // 친구 요청을 보내는 현재 로그인한 유저
 

--- a/src/main/java/com/example/YNN/repository/FriendRepository.java
+++ b/src/main/java/com/example/YNN/repository/FriendRepository.java
@@ -13,8 +13,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     List<Friend> findByUser_UserIdAndStatus(String userId, FriendRequestStatus status);
 
-//    @Transactional(readOnly = true)
-//    List<Friend> findByUser_UserId(String userId);
 
     List<Friend> findByUser_UserIdAndStatusIn(String userId, List<FriendRequestStatus> statuses);
 }


### PR DESCRIPTION
### 주요 수정 기능

- 친구 추가 시 `existingFriend`의 `NullPointerException` 발생

- `UserA`가 `UserB`에게 친구 추가 후 `ACCEPTED` ➡ 현재 `UserA`와 `UserB`는 친구인 상태 ➡ `UserB`가 `UserA`에게 친구 요청이 보내지는 오류 ➡ 양방향 설정으로 해당 경우에도 이미 친구인 상태라는 `CustomException`처리 완료.

- `UserA`가 `UserB`에게 친구 요청 후, 해당 요청을 취소하기 위해 `UserA`가 `UserB`의 친구 요청을 취소 ➡ 이 후 `UserA`의 정보가 `CascadeType.ALL` 설정으로 인하여 `Users` 테이블에서 삭제가 됨 ➡ `CascadeType.PERSIST`로 설정 변경 후 해당 오류 수정

### 주요 수정 코드

## Friend
```java
    @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
    @JoinColumn(name = "userId")
    private User user; // 친구 요청을 보내는 현재 로그인한 유저
```

## addFriend Method
```java
        // 이미 존재하는 친구 요청 조회 (거절된 상태 포함)
        Friend existingFriend = friendRepository.findByUser_UserIdAndFriendId(userId, friendId);
        Friend existingUser = friendRepository.findByUser_UserIdAndFriendId(friendId, userId);

        // 친구 상태 확인
        if ((existingFriend != null && existingFriend.getStatus() == FriendRequestStatus.ACCEPTED) ||
                (existingUser != null && existingUser.getStatus() == FriendRequestStatus.ACCEPTED)) {
            throw new CustomException(ErrorCode.EXITS_FRIENDS_USER_ID, ErrorCode.EXITS_FRIENDS_USER_ID.getMessage());
        }
        //* 양방향 관계 확인해야함
```