### PR TITLE
🐛Fix : 친구 요청 목록 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@
 | :white_check_mark: | test    | 테스트 코드 추가/수정                                 |
 | :pushpin:          | chore   | 패키지 매니저 수정, 그 외 기타 수정 ex) .gitignore    |
 | 🛠️                 | merge   | 병합      |
+
+
+## 💻 YNN Service Architecture
+
+![영남냥 drawio](https://github.com/user-attachments/assets/a580f54e-1d17-4bde-a0ff-c864e21c982f)

--- a/src/main/java/com/example/YNN/controller/FriendController.java
+++ b/src/main/java/com/example/YNN/controller/FriendController.java
@@ -116,6 +116,19 @@ public class FriendController {
         return ResponseEntity.ok(sentRequests);
     }
 
+    // 친구 요청 받은 목록 조회 API
+    @GetMapping("/api/friend/received-requests")
+    public ResponseEntity<List<FriendResponseDTO>> getReceivedFriendRequests(@RequestHeader("Authorization") String token) {
+        if (!jwtUtil.validationToken(jwtUtil.getAccessToken(token))) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        String userId = jwtUtil.getUserId(token);
+
+        List<FriendResponseDTO> receivedRequests = friendService.getReceivedFriendRequests(userId);
+        return ResponseEntity.ok(receivedRequests);
+    }
+
     @GetMapping("/api/friend/profile")
     public ResponseEntity<?> getFriendProfile(@RequestParam("friendId") String friendId,@RequestHeader("Authorization")String token){
         if(!jwtUtil.validationToken(jwtUtil.getAccessToken(token))){

--- a/src/main/java/com/example/YNN/repository/FriendRepository.java
+++ b/src/main/java/com/example/YNN/repository/FriendRepository.java
@@ -15,4 +15,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
 
     List<Friend> findByUser_UserIdAndStatusIn(String userId, List<FriendRequestStatus> statuses);
+
+    List<Friend> findAllByFriendIdAndStatus(String friendId, FriendRequestStatus status);
 }

--- a/src/main/java/com/example/YNN/service/FriendService.java
+++ b/src/main/java/com/example/YNN/service/FriendService.java
@@ -24,8 +24,11 @@ public interface FriendService {
     // 친구 요청 취소
     FriendResponseDTO cancelFriendRequest(String userId, String friendId);
 
-    // 친구 요청 목록 조회
+    // 친구 요청 보낸 목록 조회
     List<FriendResponseDTO> getSentFriendRequests(String userId);
+
+    // 친구 요청 받은 목록 조회
+    List<FriendResponseDTO> getReceivedFriendRequests(String userId);
 
     //친구 프로필 조회
     FriendProfileDTO getFriendProfile(String friendId);

--- a/src/main/java/com/example/YNN/service/FriendServiceImpl.java
+++ b/src/main/java/com/example/YNN/service/FriendServiceImpl.java
@@ -152,7 +152,7 @@ public class FriendServiceImpl implements FriendService {
     @Override
     @Transactional(readOnly = true)
     public List<FriendResponseDTO> getSentFriendRequests(String userId) {
-        // REQUESTED 상태인 친구 요청 목록 조회
+        // REQUESTED 상태인 목록 조회
         List<FriendRequestStatus> statuses = List.of(FriendRequestStatus.REQUESTED);
 
         List<Friend> sentRequests = friendRepository.findByUser_UserIdAndStatusIn(userId, statuses);
@@ -162,6 +162,22 @@ public class FriendServiceImpl implements FriendService {
                         .message("친구 요청을 보냈습니다.")
                         .status(friend.getStatus())
                         .friendId(friend.getFriendId())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FriendResponseDTO> getReceivedFriendRequests(String userId) {
+        // 친구 요청을 받은 목록 조회
+        List<Friend> receivedRequests = friendRepository.findAllByFriendIdAndStatus(userId, FriendRequestStatus.REQUESTED);
+
+        // Friend 엔터티를 FriendResponseDTO로 변환
+        return receivedRequests.stream()
+                .map(request -> FriendResponseDTO.builder()
+                        .message("친구 요청을 받았습니다.")
+                        .status(request.getStatus())
+                        .friendId(request.getUser().getUserId())
                         .build())
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
### 주요 수정 기능

- 친구 요청 목록을 확인하면 양방향 관계를 확인하지 않고 겹쳐서 목록이 뜨는 경우 발생
- Ex ) A -> B 친구 요청 보냄 ➡ A -> B 친구 요청 목록 확인만 가능, 친구 수락 및 거절은 B가 해야함 ➡ A가 친구 수락 및 거절이 가능한 버그를 API를 구분하여 목록을 띄움.

### 주요 수정 코드

## FriendController
```java
    // 친구 요청 받은 목록 조회 API
    @GetMapping("/api/friend/received-requests")
    public ResponseEntity<List<FriendResponseDTO>> getReceivedFriendRequests(@RequestHeader("Authorization") String token) {
        if (!jwtUtil.validationToken(jwtUtil.getAccessToken(token))) {
            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
        }

        String userId = jwtUtil.getUserId(token);

        List<FriendResponseDTO> receivedRequests = friendService.getReceivedFriendRequests(userId);
        return ResponseEntity.ok(receivedRequests);
    }
```

## FriendServiceImpl
```java
    @Override
    @Transactional(readOnly = true)
    public List<FriendResponseDTO> getReceivedFriendRequests(String userId) {
        // 친구 요청을 받은 목록 조회
        List<Friend> receivedRequests = friendRepository.findAllByFriendIdAndStatus(userId, FriendRequestStatus.REQUESTED);

        // Friend 엔터티를 FriendResponseDTO로 변환
        return receivedRequests.stream()
                .map(request -> FriendResponseDTO.builder()
                        .message("친구 요청을 받았습니다.")
                        .status(request.getStatus())
                        .friendId(request.getUser().getUserId())
                        .build())
                .collect(Collectors.toList());
    }
```